### PR TITLE
feat: relax RLS for tosabendo2 bucket

### DIFF
--- a/Supabase Snippet Row-Level Security Policy Audit.csv
+++ b/Supabase Snippet Row-Level Security Policy Audit.csv
@@ -70,4 +70,4 @@ public,tasks,postgres,true,false,Block all direct writes,PERMISSIVE,*,null,false
 public,tasks,postgres,true,false,tasks_members,PERMISSIVE,*,null,"is_project_member(project_id, auth.uid())",null
 storage,objects,supabase_storage_admin,true,false,Allow authenticated read access,PERMISSIVE,r,{authenticated},((bucket_id = 'user_uploads'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text)),null
 storage,objects,supabase_storage_admin,true,false,Allow authenticated uploads,PERMISSIVE,a,{authenticated},null,((bucket_id = 'user_uploads'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text))
-storage,objects,supabase_storage_admin,true,false,Permitir acesso total a membros do projeto,PERMISSIVE,*,{authenticated},"((bucket_id = 'tosabendo2'::text) AND is_project_member(get_project_id_from_path(name), auth.uid()))","((bucket_id = 'tosabendo2'::text) AND is_project_member(get_project_id_from_path(name), auth.uid()))"
+storage,objects,supabase_storage_admin,true,false,Allow full access to tosabendo2 bucket,PERMISSIVE,*,{authenticated},(bucket_id = 'tosabendo2'::text),(bucket_id = 'tosabendo2'::text)

--- a/schema.rd
+++ b/schema.rd
@@ -707,11 +707,11 @@
     "table_owner": "supabase_storage_admin",
     "rls_enabled": true,
     "rls_forced": false,
-    "policy_name": "Permitir acesso total a membros do projeto",
+    "policy_name": "Allow full access to tosabendo2 bucket",
     "mode": "PERMISSIVE",
     "command": "*",
     "roles": "{authenticated}",
-    "using_expression": "((bucket_id = 'tosabendo2'::text) AND is_project_member(get_project_id_from_path(name), auth.uid()))",
-    "with_check_expression": "((bucket_id = 'tosabendo2'::text) AND is_project_member(get_project_id_from_path(name), auth.uid()))"
+    "using_expression": "(bucket_id = 'tosabendo2'::text)",
+    "with_check_expression": "(bucket_id = 'tosabendo2'::text)"
   }
 ]


### PR DESCRIPTION
## Summary
- allow authenticated users full access to tosabendo2 bucket without project membership check

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompted for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a07dc5ae3c8321a91ba7f1c1f0dea0