### PR TITLE
Add timestamp triggers for key tables

### DIFF
--- a/src/migrations/new_032_set_timestamp_trigger.sql
+++ b/src/migrations/new_032_set_timestamp_trigger.sql
@@ -1,0 +1,29 @@
+-- supabase/migrations/new_032_set_timestamp_trigger.sql
+
+CREATE OR REPLACE FUNCTION public.set_timestamp()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+-- Attach trigger to projects
+DROP TRIGGER IF EXISTS set_timestamp ON public.projects;
+CREATE TRIGGER set_timestamp
+BEFORE INSERT OR UPDATE ON public.projects
+FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();
+
+-- Attach trigger to tasks
+DROP TRIGGER IF EXISTS set_timestamp ON public.tasks;
+CREATE TRIGGER set_timestamp
+BEFORE INSERT OR UPDATE ON public.tasks
+FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();
+
+-- Attach trigger to task_observations
+DROP TRIGGER IF EXISTS set_timestamp ON public.task_observations;
+CREATE TRIGGER set_timestamp
+BEFORE INSERT OR UPDATE ON public.task_observations
+FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();


### PR DESCRIPTION
## Summary
- add reusable `set_timestamp` trigger function
- automatically update `updated_at` on `projects`, `tasks`, and `task_observations`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run typecheck` *(fails: src/components/projects/import-project-modal.tsx(119,1): error TS1128: Declaration or statement expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68a07ddef6888321a23fdd0c0af8a5af