### PR TITLE
Add timestamp trigger for core tables

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -129,7 +129,7 @@ CREATE INDEX IF NOT EXISTS idx_task_tags_task_tag ON public.task_tags(task_id, t
 CREATE OR REPLACE FUNCTION public.set_timestamp()
 RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
-  NEW.updated_at := now();
+  NEW.updated_at = now();
   RETURN NEW;
 END $$;
 

--- a/src/migrations/new_032_set_timestamp_trigger.sql
+++ b/src/migrations/new_032_set_timestamp_trigger.sql
@@ -13,17 +13,17 @@ $$;
 -- Attach trigger to projects
 DROP TRIGGER IF EXISTS set_timestamp ON public.projects;
 CREATE TRIGGER set_timestamp
-BEFORE INSERT OR UPDATE ON public.projects
+BEFORE UPDATE ON public.projects
 FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();
 
 -- Attach trigger to tasks
 DROP TRIGGER IF EXISTS set_timestamp ON public.tasks;
 CREATE TRIGGER set_timestamp
-BEFORE INSERT OR UPDATE ON public.tasks
+BEFORE UPDATE ON public.tasks
 FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();
 
 -- Attach trigger to task_observations
 DROP TRIGGER IF EXISTS set_timestamp ON public.task_observations;
 CREATE TRIGGER set_timestamp
-BEFORE INSERT OR UPDATE ON public.task_observations
+BEFORE UPDATE ON public.task_observations
 FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();


### PR DESCRIPTION
## Summary
- define `public.set_timestamp` to refresh `updated_at`
- ensure projects, tasks, and task_observations call `set_timestamp` before updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a0984f58248321b27037c65e2713b3