### PR TITLE
feat: add b-tree indexes for task relations

### DIFF
--- a/src/migrations/new_033_add_task_indexes.sql
+++ b/src/migrations/new_033_add_task_indexes.sql
@@ -1,0 +1,13 @@
+-- supabase/migrations/new_033_add_task_indexes.sql
+
+-- Create B-tree index for tasks project and assignee
+CREATE INDEX IF NOT EXISTS idx_tasks_project_assignee
+    ON public.tasks USING btree (project_id, assignee_id);
+
+-- Create B-tree index for task observations by task and creation time
+CREATE INDEX IF NOT EXISTS idx_task_obs_task_created
+    ON public.task_observations USING btree (task_id, created_at);
+
+-- Create B-tree index for task tags by task and tag
+CREATE INDEX IF NOT EXISTS idx_task_tags_task_tag
+    ON public.task_tags USING btree (task_id, tag_id);


### PR DESCRIPTION
## Summary
- create b-tree indexes on tasks, task_observations, and task_tags tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a09852ff24832194c92251c1b3e8d7