### PR TITLE
Add trigger-based project change logging

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -281,6 +281,44 @@ CREATE TRIGGER set_timestamp_task_obs
   BEFORE UPDATE ON public.task_observations
   FOR EACH ROW EXECUTE FUNCTION public.set_timestamp();
 
+-- Trigger function to log project and task changes
+DROP FUNCTION IF EXISTS public.log_project_change() CASCADE;
+CREATE OR REPLACE FUNCTION public.log_project_change(description text)
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_project_id uuid;
+BEGIN
+  IF TG_TABLE_NAME = 'projects' THEN
+    v_project_id := COALESCE(NEW.id, OLD.id);
+  ELSE
+    v_project_id := COALESCE(NEW.project_id, OLD.project_id);
+  END IF;
+
+  INSERT INTO public.project_change_log (project_id, author_id, description)
+  VALUES (v_project_id, auth.uid(), description || ' ' || TG_OP);
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+-- Triggers to log changes in projects and tasks
+DROP TRIGGER IF EXISTS trg_projects_change_log ON public.projects;
+CREATE TRIGGER trg_projects_change_log
+  AFTER INSERT OR UPDATE OR DELETE ON public.projects
+  FOR EACH ROW EXECUTE FUNCTION public.log_project_change('Project');
+
+DROP TRIGGER IF EXISTS trg_tasks_change_log ON public.tasks;
+CREATE TRIGGER trg_tasks_change_log
+  AFTER INSERT OR UPDATE OR DELETE ON public.tasks
+  FOR EACH ROW EXECUTE FUNCTION public.log_project_change('Task');
+
 -- ================================================================
 -- RLS Policies
 -- ================================================================

--- a/src/migrations/new_032_project_task_change_log.sql
+++ b/src/migrations/new_032_project_task_change_log.sql
@@ -1,59 +1,42 @@
 -- supabase/migrations/new_032_project_task_change_log.sql
 
 -- Trigger function to log project and task changes
-CREATE OR REPLACE FUNCTION public.log_project_change()
+DROP FUNCTION IF EXISTS public.log_project_change() CASCADE;
+CREATE OR REPLACE FUNCTION public.log_project_change(description text)
 RETURNS TRIGGER
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
   v_project_id uuid;
-  v_description text;
 BEGIN
   IF TG_TABLE_NAME = 'projects' THEN
-    v_project_id := NEW.id;
-    IF NEW.name IS DISTINCT FROM OLD.name THEN
-      v_description := format('Project name changed from %s to %s', OLD.name, NEW.name);
-    ELSIF NEW.description IS DISTINCT FROM OLD.description THEN
-      v_description := 'Project description updated';
-    ELSIF NEW.start_date IS DISTINCT FROM OLD.start_date OR NEW.end_date IS DISTINCT FROM OLD.end_date THEN
-      v_description := 'Project dates updated';
-    ELSE
-      RETURN NEW;
-    END IF;
+    v_project_id := COALESCE(NEW.id, OLD.id);
   ELSE
-    -- TG_TABLE_NAME = 'tasks'
-    v_project_id := NEW.project_id;
-    IF NEW.title IS DISTINCT FROM OLD.title THEN
-      v_description := format('Task title changed from %s to %s', OLD.title, NEW.title);
-    ELSIF NEW.status_id IS DISTINCT FROM OLD.status_id THEN
-      v_description := 'Task status updated';
-    ELSIF NEW.assignee_id IS DISTINCT FROM OLD.assignee_id THEN
-      v_description := 'Task assignment updated';
-    ELSIF NEW.start_date IS DISTINCT FROM OLD.start_date OR NEW.due_date IS DISTINCT FROM OLD.due_date THEN
-      v_description := 'Task dates updated';
-    ELSE
-      RETURN NEW;
-    END IF;
+    v_project_id := COALESCE(NEW.project_id, OLD.project_id);
   END IF;
 
-  INSERT INTO public.project_change_log (project_id, user_id, description, created_at, updated_at)
-  VALUES (v_project_id, auth.uid(), v_description, now(), now());
+  INSERT INTO public.project_change_log (project_id, author_id, description)
+  VALUES (v_project_id, auth.uid(), description || ' ' || TG_OP);
 
-  RETURN NEW;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
 END;
 $$;
 
 -- Trigger for changes in projects
 DROP TRIGGER IF EXISTS trg_projects_change_log ON public.projects;
 CREATE TRIGGER trg_projects_change_log
-AFTER UPDATE OF name, description, start_date, end_date ON public.projects
+AFTER INSERT OR UPDATE OR DELETE ON public.projects
 FOR EACH ROW
-EXECUTE FUNCTION public.log_project_change();
+EXECUTE FUNCTION public.log_project_change('Project');
 
 -- Trigger for changes in tasks
 DROP TRIGGER IF EXISTS trg_tasks_change_log ON public.tasks;
 CREATE TRIGGER trg_tasks_change_log
-AFTER UPDATE OF title, status_id, assignee_id, start_date, due_date ON public.tasks
+AFTER INSERT OR UPDATE OR DELETE ON public.tasks
 FOR EACH ROW
-EXECUTE FUNCTION public.log_project_change();
+EXECUTE FUNCTION public.log_project_change('Task');


### PR DESCRIPTION
## Summary
- add `log_project_change` trigger function to insert change events in `project_change_log`
- record insert, update, and delete operations on `projects` and `tasks` via new triggers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: src/components/projects/import-project-modal.tsx(119,1): error TS1128: Declaration or statement expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68a098555ee08321b08b718d87215874