### PR TITLE
feat: add task status and priority tables

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -53,19 +53,39 @@ CREATE TABLE IF NOT EXISTS public.task_statuses (
   color text
 );
 
+CREATE TABLE IF NOT EXISTS public.task_priorities (
+  id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  rank integer
+);
+
 CREATE TABLE IF NOT EXISTS public.tasks (
   id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   project_id  uuid NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
-  title       text NOT NULL,
+  name        text NOT NULL,
   description text,
   assignee_id uuid REFERENCES public.profiles(id),
   status_id   uuid REFERENCES public.task_statuses(id),
+  priority_id uuid REFERENCES public.task_priorities(id),
   start_date  date,
   end_date    date,
   due_date    date,
   created_at  timestamptz NOT NULL DEFAULT now(),
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
+
+-- Seed default statuses and priorities
+INSERT INTO public.task_statuses (name, color) VALUES
+  ('To Do', '#6b7280'),
+  ('In Progress', '#3b82f6'),
+  ('Done', '#10b981')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.task_priorities (name, rank) VALUES
+  ('High', 1),
+  ('Medium', 2),
+  ('Low', 3)
+ON CONFLICT (name) DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS public.task_observations (
   id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/hooks/use-table-settings.tsx
+++ b/src/hooks/use-table-settings.tsx
@@ -5,7 +5,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useUsers } from './use-users';
 
 // --- Tipos ---
-export interface TaskStatus { id: string; name: string; color: string; display_order?: number; }
+export interface TaskStatus { id: string; name: string; color: string; }
 export interface Tag { id: string; name: string; color?: string; }
 export interface Column { id: string; name: string; type: 'text' | 'number' | 'date' | 'progress'; is_custom?: boolean; }
 export type SortDirection = 'asc' | 'desc';
@@ -73,7 +73,7 @@ export const TableSettingsProvider = ({ children }: { children: ReactNode }) => 
         }
         setLoading(true);
         const [statusRes, tagsRes] = await Promise.all([
-            supabase.from('task_statuses').select('*').order('display_order'),
+            supabase.from('task_statuses').select('*').order('name'),
             supabase.from('tags').select('*'),
         ]);
         if (statusRes.error) throw statusRes.error;

--- a/src/hooks/use-tasks.tsx
+++ b/src/hooks/use-tasks.tsx
@@ -134,7 +134,7 @@ export const TasksProvider = ({ children }: { children: ReactNode }) => {
         p_task_id: taskId || null, p_project_id: finalProjectId,
         p_name: taskData.name || null, p_description: taskData.description || null,
         p_assignee_id: taskData.assignee_id || null, p_status_id: taskData.status_id || null,
-        p_priority: taskData.priority || 'Média', p_progress: taskData.progress || 0,
+        p_priority: taskData.priority || 'Medium', p_progress: taskData.progress || 0,
         p_start_date: formatTaskDate(taskData.start_date),
         p_end_date: formatTaskDate(taskData.end_date),
         p_parent_id: taskData.parent_id || null, p_is_milestone: taskData.is_milestone || false,

--- a/src/lib/critical-path.test.ts
+++ b/src/lib/critical-path.test.ts
@@ -5,7 +5,7 @@ describe('getCriticalPath', () => {
   const baseTask: Omit<Task, 'id' | 'dependency_ids' | 'start_date' | 'end_date'> = {
     formatted_id: '',
     name: '',
-    priority: 'Média',
+    priority: 'Medium',
     progress: 0,
     is_milestone: false,
     project_id: 'p1'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 // src/lib/types.ts
 
 // Tipos Enum para conformidade com a base de dados
-export type TaskPriority = 'Baixa' | 'Média' | 'Alta';
+export type TaskPriority = 'Low' | 'Medium' | 'High';
 export type CollaboratorRole = 'Gerente' | 'Membro';
 
 // Interface para o perfil de um usuário
@@ -31,7 +31,6 @@ export interface TaskStatus {
   id: string;
   name: string;
   color: string;
-  display_order: number;
 }
 
 // Interface para uma Tag (ex: Bug, Melhoria)
@@ -50,6 +49,7 @@ export interface Task {
   assignee_id?: string;
   status_id?: string;
   priority: TaskPriority;
+  priority_id?: string;
   start_date?: string;
   end_date?: string;
   progress: number;

--- a/src/migrations/new_032_add_task_priorities.sql
+++ b/src/migrations/new_032_add_task_priorities.sql
@@ -4,8 +4,7 @@
 CREATE TABLE IF NOT EXISTS public.task_statuses (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   name text NOT NULL UNIQUE,
-  color text,
-  display_order integer
+  color text
 );
 
 CREATE TABLE IF NOT EXISTS public.task_priorities (
@@ -15,16 +14,16 @@ CREATE TABLE IF NOT EXISTS public.task_priorities (
 );
 
 -- Seed default data
-INSERT INTO public.task_statuses (name, color, display_order) VALUES
-  ('Pendente', '#6b7280', 1),
-  ('Em Progresso', '#3b82f6', 2),
-  ('Concluído', '#10b981', 3)
+INSERT INTO public.task_statuses (name, color) VALUES
+  ('To Do', '#6b7280'),
+  ('In Progress', '#3b82f6'),
+  ('Done', '#10b981')
 ON CONFLICT (name) DO NOTHING;
 
 INSERT INTO public.task_priorities (name, rank) VALUES
-  ('Alta', 1),
-  ('Média', 2),
-  ('Baixa', 3)
+  ('High', 1),
+  ('Medium', 2),
+  ('Low', 3)
 ON CONFLICT (name) DO NOTHING;
 
 -- Replace text columns in tasks with foreign keys

--- a/src/migrations/new_032_project_task_change_log.sql
+++ b/src/migrations/new_032_project_task_change_log.sql
@@ -24,8 +24,8 @@ BEGIN
   ELSE
     -- TG_TABLE_NAME = 'tasks'
     v_project_id := NEW.project_id;
-    IF NEW.title IS DISTINCT FROM OLD.title THEN
-      v_description := format('Task title changed from %s to %s', OLD.title, NEW.title);
+    IF NEW.name IS DISTINCT FROM OLD.name THEN
+      v_description := format('Task name changed from %s to %s', OLD.name, NEW.name);
     ELSIF NEW.status_id IS DISTINCT FROM OLD.status_id THEN
       v_description := 'Task status updated';
     ELSIF NEW.assignee_id IS DISTINCT FROM OLD.assignee_id THEN
@@ -54,6 +54,6 @@ EXECUTE FUNCTION public.log_project_change();
 -- Trigger for changes in tasks
 DROP TRIGGER IF EXISTS trg_tasks_change_log ON public.tasks;
 CREATE TRIGGER trg_tasks_change_log
-AFTER UPDATE OF title, status_id, assignee_id, start_date, due_date ON public.tasks
+AFTER UPDATE OF name, status_id, assignee_id, start_date, due_date ON public.tasks
 FOR EACH ROW
 EXECUTE FUNCTION public.log_project_change();


### PR DESCRIPTION
## Summary
- add task_statuses and task_priorities tables with default seed data
- swap task name columns to foreign keys for status and priority
- update types and hooks for new priority model

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Declaration or statement expected in import-project-modal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a09856a8448321813e3e0dc6c3c0d2